### PR TITLE
Drop support to Julia 0.7, add Project.toml and delete REQUIRE files

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,15 +6,12 @@ os:
   - osx
 
 julia:
-  - 0.7
   - 1.0
   - 1.1
   - nightly
 
 matrix:
    allow_failures:
-     - julia: 1.0
-     - julia: 1.1
      - julia: nightly
 
 notifications:

--- a/Project.toml
+++ b/Project.toml
@@ -17,7 +17,7 @@ TaylorSeries = "6aa5eb33-94cf-58f4-a9d0-e4b2c4fc25ea"
 Documenter = "≥ 0.22.1"
 IntervalArithmetic = "≥ 0.15.1"
 Reexport = "≥ 0.2.0"
-TaylorIntegration = "≥ 0.5.0"
+TaylorIntegration = "^ 0.4"
 TaylorSeries = "≥ 0.10.0"
 julia = "≥ 1.0.0"
 

--- a/Project.toml
+++ b/Project.toml
@@ -1,0 +1,30 @@
+name = "TaylorModels"
+uuid = "314ce334-5f6e-57ae-acf6-00b6e903104a"
+repo = "https://github.com/JuliaIntervals/TaylorModels.jl.git"
+version = "0.1.1"
+
+[deps]
+Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+IntervalArithmetic = "d1acc4aa-44c8-5952-acd4-ba5d80a2a253"
+LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+Markdown = "d6f4376e-aef5-505a-96c1-9c027394607a"
+RecipesBase = "3cdcf5f2-1ef4-517c-9805-6587b60abb01"
+Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
+TaylorIntegration = "92b13dbe-c966-51a2-8445-caca9f8a7d42"
+TaylorSeries = "6aa5eb33-94cf-58f4-a9d0-e4b2c4fc25ea"
+
+[compat]
+Documenter = "≥ 0.22.1"
+IntervalArithmetic = "≥ 0.15.1"
+Reexport = "≥ 0.2.0"
+TaylorIntegration = "≥ 0.5.0"
+TaylorSeries = "≥ 0.10.0"
+julia = "≥ 1.0.0"
+
+[extras]
+Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[targets]
+test = ["Documenter", "LinearAlgebra", "Test"]

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,7 +1,0 @@
-julia 0.7
-Reexport v0.2.0
-TaylorSeries v0.8.1
-IntervalArithmetic v0.15.1
-TaylorIntegration v0.4.0
-RecipesBase
-Documenter v0.22.1

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,5 @@
 environment:
   matrix:
-  - julia_version: 0.7
   - julia_version: 1.0
   - julia_version: 1.1
   - julia_version: nightly
@@ -12,8 +11,6 @@ platform:
 # (tests will run but not make your overall status red)
 matrix:
   allow_failures:
-  - julia_version: 1.0
-  - julia_version: 1.1
   - julia_version: nightly
 
 branches:

--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,1 +1,0 @@
-Documenter


### PR DESCRIPTION
This cherry-picks 2497729 from `lb/shrinkwrap`.