### PR TITLE
Update validatedODEs.jl

### DIFF
--- a/src/validatedODEs.jl
+++ b/src/validatedODEs.jl
@@ -458,7 +458,7 @@ function validated_integ(f!, qq0::AbstractArray{T,1}, δq0::IntervalBox{N,T},
         end
 
         if nsteps > maxsteps
-            @info("""
+            @warn("""
             Maximum number of integration steps reached; exiting.
             """)
             break


### PR DESCRIPTION
If maxsteps are reached, the simulation cannot go to the desired time horizon, so a warning message seems more appropriate (referenced from [this issue](https://github.com/JuliaReach/Reachability.jl/pull/701)).