### PR TITLE
Add constructors for just changing the remainder

### DIFF
--- a/src/constructors.jl
+++ b/src/constructors.jl
@@ -31,6 +31,9 @@ for TM in tupleTMs
         # Outer constructors
         $(TM)(pol::Taylor1{T}, rem::Interval{S},
             x0::Interval{S}, dom::Interval{S}) where {T,S} = $(TM){T,S}(pol, rem, x0, dom)
+        
+        # Constructor just chainging the remainder
+        $(TM)(u::$(TM){T, S}, Δ::Interval{S}) where {T, S} = $(TM){T, S}(u.pol, Δ, u.x0, u.dom) 
 
         # Short-cut for independent variable
         $(TM)(ord::Integer, x0, dom::Interval{T}) where {T} =
@@ -47,7 +50,7 @@ for TM in tupleTMs
         # convenience constructors with same n, x0, I:
         # TaylorModel1(f, p, Δ) = TaylorModel1(f.n, f.x0, f.dom, p, Δ)
         # TaylorModel1(f, Δ) = TaylorModel1(f, f.p, Δ)
-
+    
         # Functions to retrieve the order and remainder
         get_order(tm::$TM) = get_order(tm.pol)
         remainder(tm::$TM) = tm.rem
@@ -124,6 +127,9 @@ end
 # Outer constructors
 TaylorModelN(pol::TaylorN{T}, rem::Interval{S}, x0::IntervalBox{N,S}, dom::IntervalBox{N,S}) where {N,T,S} =
     TaylorModelN{N,T,S}(pol, rem, x0, dom)
+
+# Constructor for just changing the remainder
+TaylorModelN(u::TaylorModelN{N, T, S}, Δ::R) where {N, T, S, R} = TaylorModelN{N, T, S}(u.pol, Δ, u.x0, u.dom) 
 
 # Short-cut for independent variable
 TaylorModelN(nv::Integer, ord::Integer, x0::IntervalBox{N,T}, dom::IntervalBox{N,T}) where {N,T} =

--- a/test/TM1.jl
+++ b/test/TM1.jl
@@ -52,6 +52,11 @@ end
         @test tv == TaylorModel1(5, 0.0, ii0)
         @test TaylorModel1(x1, 5, x0, ii0) == TaylorModel1(Taylor1(x1, 5), x0, x0, ii0)
         @test TaylorModel1(5, 0.7, ii1) == TaylorModel1(5, interval(0.7), ii1)
+        
+        @test TaylorModel1(tv, ii0) == 
+        TaylorModel1{Interval{Float64}, Float64}(Taylor1(Interval{Float64}, 5), ii0, x0, ii0)
+        @test TaylorModel1(5, x0, ii0) == TaylorModel1(tv, x0)
+        @test TaylorModel1(5, ii0) == TaylorModel1(tv, x0)
 
         @test isa(tv, AbstractSeries)
         @test TaylorModel1{Interval{Float64},Float64} <: AbstractSeries{Interval{Float64}}
@@ -364,6 +369,11 @@ end
         @test tv == RTaylorModel1(5, 0.0, ii0)
         @test RTaylorModel1(x1, 5, x0, ii0) == RTaylorModel1(Taylor1(x1, 5), x0, x0, ii0)
         @test RTaylorModel1(5, 0.7, ii1) == RTaylorModel1(5, interval(0.7), ii1)
+        
+        @test RTaylorModel1(tv, ii0) == 
+        RTaylorModel1{Interval{Float64}, Float64}(Taylor1(Interval{Float64}, 5), ii0, x0, ii0)
+        @test RTaylorModel1(5, x0, ii0) == RTaylorModel1(tv, x0)
+        @test RTaylorModel1(5, ii0) == RTaylorModel1(tv, x0)
 
         @test isa(tv, AbstractSeries)
         @test RTaylorModel1{Interval{Float64},Float64} <: AbstractSeries{Interval{Float64}}

--- a/test/TM1.jl
+++ b/test/TM1.jl
@@ -53,8 +53,7 @@ end
         @test TaylorModel1(x1, 5, x0, ii0) == TaylorModel1(Taylor1(x1, 5), x0, x0, ii0)
         @test TaylorModel1(5, 0.7, ii1) == TaylorModel1(5, interval(0.7), ii1)
         
-        @test TaylorModel1(tv, ii0) == 
-        TaylorModel1{Interval{Float64}, Float64}(Taylor1(Interval{Float64}, 5), ii0, x0, ii0)
+        @test TaylorModel1(tv, ii0) == TaylorModel1(Taylor1(Interval{Float64}, 5), ii0, x0, ii0)
         @test TaylorModel1(5, x0, ii0) == TaylorModel1(tv, x0)
         @test TaylorModel1(5, ii0) == TaylorModel1(tv, x0)
 
@@ -370,8 +369,7 @@ end
         @test RTaylorModel1(x1, 5, x0, ii0) == RTaylorModel1(Taylor1(x1, 5), x0, x0, ii0)
         @test RTaylorModel1(5, 0.7, ii1) == RTaylorModel1(5, interval(0.7), ii1)
         
-        @test RTaylorModel1(tv, ii0) == 
-        RTaylorModel1{Interval{Float64}, Float64}(Taylor1(Interval{Float64}, 5), ii0, x0, ii0)
+        @test RTaylorModel1(tv, ii0) == RTaylorModel1(Taylor1(Interval{Float64}, 5), ii0, x0, ii0)
         @test RTaylorModel1(5, x0, ii0) == RTaylorModel1(tv, x0)
         @test RTaylorModel1(5, ii0) == RTaylorModel1(tv, x0)
 

--- a/test/TMN.jl
+++ b/test/TMN.jl
@@ -43,7 +43,7 @@ set_variables(Interval{Float64}, [:x, :y], order=_order_max)
         @test TaylorModelN( b1[1], 2, b0, ib0) ==
                 TaylorModelN(TaylorN(b1[1], _order), zi, b0, ib0)
         
-        @test TaylorModelN(xm, -1..1) == TaylorModelN{2, Interval{Float64}, Float64}(xT, -1..1, b0, ib0)
+        @test TaylorModelN(xm, -1..1) == TaylorModelN(xT, -1..1, b0, ib0)
         @test TaylorModelN(1, _order, b0, ib0) == TaylorModelN(xm, zi)
         @test TaylorModelN(2, _order, b0, ib0) == TaylorModelN(ym, zi)
 

--- a/test/TMN.jl
+++ b/test/TMN.jl
@@ -42,6 +42,10 @@ set_variables(Interval{Float64}, [:x, :y], order=_order_max)
         @test ym == TaylorModelN(2, _order, b0, ib0)
         @test TaylorModelN( b1[1], 2, b0, ib0) ==
                 TaylorModelN(TaylorN(b1[1], _order), zi, b0, ib0)
+        
+        @test TaylorModelN(xm, -1..1) == TaylorModelN{2, Interval{Float64}, Float64}(xT, -1..1, b0, ib0)
+        @test TaylorModelN(1, _order, b0, ib0) == TaylorModelN(xm, zi)
+        @test TaylorModelN(2, _order, b0, ib0) == TaylorModelN(ym, zi)
 
         @test isa(xm, AbstractSeries)
         @test TaylorModelN{2, Interval{Float64},Float64} <: AbstractSeries{Interval{Float64}}


### PR DESCRIPTION
This adds constructors for `TaylorModel1`(`RTaylorModel1`) and `TaylorModelN` as proposed by #28.