### PR TITLE
fix warning with derivative

### DIFF
--- a/src/TaylorModels.jl
+++ b/src/TaylorModels.jl
@@ -18,6 +18,8 @@ import Base: setindex!, getindex, copy, firstindex, lastindex,
     inv, sqrt, exp, log, sin, cos, tan,
     asin, acos, atan, sinh, cosh, tanh
 
+using TaylorSeries: derivative, ∇
+
 import TaylorSeries: integrate, get_order, evaluate, pretty_print,
     constant_term, linear_polynomial, fixorder
 


### PR DESCRIPTION
On master,

```julia
julia> using TaylorModels
[ Info: Precompiling TaylorModels [314ce334-5f6e-57ae-acf6-00b6e903104a]

julia> derivative
WARNING: both IntervalRootFinding and TaylorIntegration export "derivative"; uses of it in module TaylorModels must be qualified
ERROR: UndefVarError: derivative not defined

julia> ∇
WARNING: both IntervalRootFinding and TaylorIntegration export "∇"; uses of it in module TaylorModels must be qualified
ERROR: UndefVarError: ∇ not defined
```
This branch changes such behavior to

```julia
julia> using TaylorModels
[ Info: Precompiling TaylorModels [314ce334-5f6e-57ae-acf6-00b6e903104a]

julia> derivative
derivative (generic function with 10 methods)

julia> ∇
gradient (generic function with 1 method)
```
