### PR TITLE
updated compat for IntervalArithmetic

### DIFF
--- a/.github/workflows/CompactHelper.yml
+++ b/.github/workflows/CompactHelper.yml
@@ -1,0 +1,15 @@
+name: CompatHelper
+on:
+  schedule:
+    - cron: 0 0 * * *
+  workflow_dispatch:
+jobs:
+  CompatHelper:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Pkg.add("CompatHelper")
+        run: julia -e 'using Pkg; Pkg.add("CompatHelper")'
+      - name: CompatHelper.main()
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: julia -e 'using CompatHelper; CompatHelper.main()'

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "TaylorModels"
 uuid = "314ce334-5f6e-57ae-acf6-00b6e903104a"
 repo = "https://github.com/JuliaIntervals/TaylorModels.jl.git"
-version = "0.3.8"
+version = "0.3.9"
 
 [deps]
 IntervalArithmetic = "d1acc4aa-44c8-5952-acd4-ba5d80a2a253"
@@ -14,7 +14,7 @@ TaylorIntegration = "92b13dbe-c966-51a2-8445-caca9f8a7d42"
 TaylorSeries = "6aa5eb33-94cf-58f4-a9d0-e4b2c4fc25ea"
 
 [compat]
-IntervalArithmetic = "0.16, 0.17"
+IntervalArithmetic = "0.16, 0.17, 0.18"
 IntervalRootFinding = "0.5.1"
 RecipesBase = "0.8, 1.0"
 Reexport = "0.2, 1.0"

--- a/Project.toml
+++ b/Project.toml
@@ -15,12 +15,12 @@ TaylorSeries = "6aa5eb33-94cf-58f4-a9d0-e4b2c4fc25ea"
 
 [compat]
 IntervalArithmetic = "0.16, 0.17, 0.18"
-IntervalRootFinding = "0.5.1"
+IntervalRootFinding = "0.5"
 RecipesBase = "0.8, 1.0"
 Reexport = "0.2, 1.0"
 TaylorIntegration = "0.7, 0.8"
-TaylorSeries = "0.10"
-julia = "1.3, 1.4, 1.5"
+TaylorSeries = "0.10, 0.11"
+julia = "1.3, 1.4, 1.5, 1.6"
 
 [extras]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"


### PR DESCRIPTION
As IntervalArithmetic was updated to 0.18 recently, this pull request updates the compat entry in `Project.toml`.

Would you like me to add the CompatHelper.yml to the workflow? Once a day it checks the dependencies of the package and automatically opens a PR if some entries in compat should be updated.